### PR TITLE
fixed path to algorithms section

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@
 - [Cargo Introduction](notes/rust/cargo-intro.md)
 - [Data Structures](notes/data-structures/collections.md)
 - [Intro to ServerSide Events (SSE)](notes/SSE.md)
-- [Algorithms](notes/Algorithms/README.md)
+- [Algorithms](notes/algorithms/README.md)
 - [JS Prototypes 101](notes/js/prototypes.js)
 - [Free Software](notes/free-software.md)
 


### PR DESCRIPTION
When clicking on the algorithms section, github would give a 404.
This is because the link uses a Capital, but the folder structure is lowercase.